### PR TITLE
Add players and initial logging

### DIFF
--- a/castle-siege/package-lock.json
+++ b/castle-siege/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.7.2",
         "crypto": "^1.0.1",
         "mtgsdk": "^1.0.1",
+        "openai": "^4.56.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -4135,6 +4136,28 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
@@ -4652,6 +4675,17 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4748,6 +4782,17 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -7997,6 +8042,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -8537,6 +8590,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -9236,6 +9306,14 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -12525,6 +12603,62 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -12827,6 +12961,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.56.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.56.0.tgz",
+      "integrity": "sha512-zcag97+3bG890MNNa0DQD9dGmmTWL8unJdNkulZzWRXrl+QeD+YkBI4H58rJcwErxqGK6a0jVPZ4ReJjhDGcmw==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/optionator": {
@@ -17314,6 +17481,14 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/castle-siege/package.json
+++ b/castle-siege/package.json
@@ -9,6 +9,7 @@
     "axios": "^1.7.2",
     "crypto": "^1.0.1",
     "mtgsdk": "^1.0.1",
+    "openai": "^4.56.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",

--- a/castle-siege/src/App.js
+++ b/castle-siege/src/App.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import './css/App.scss';
 import Threat from './Threat.js';
-// import defaultBackground from 'gray-patterned-bg.jpg';
+// OpenAI
+import OpenAI from 'openai';
 
 const App = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -15,6 +16,61 @@ const App = () => {
   const [selectedMap, setSelectedMap] = useState(null);
   // const [backgroundImage, setBackgroundImage] = useState('/gray-patterned-bg.jpg');
   const [backgroundImage, setBackgroundImage] = useState(null);
+  const [isGameStarted, setIsGameStarted] = useState(false);
+
+  // Player / Commander data
+  const [commander1, setCommander1] = useState('');
+  const [commander2, setCommander2] = useState('');
+  const [commander3, setCommander3] = useState('');
+  const [commander4, setCommander4] = useState('');
+  const [commandersArray, setCommandersArray] = useState([]);
+
+  // OpenAI. Will be handled differently once secrets management is set up.
+  const [openai, setOpenai] = useState(null);
+  
+  // Game Log; plain text. Will be used to generate a summary at the end.
+  const [gameLog, setGameLog] = useState('');
+
+  const addToGameLog = (additionalText) => {
+    setGameLog(gameLog + additionalText);
+    // Has n+1 issue, but is okay just for logging.
+    console.log(`gameLog is: ${gameLog}`)
+  }
+
+  const generateGameSummary = async () => {
+
+    // Just until secrets management is implemented.
+    if(!openai) {
+      return 'OpenAI not initialized.';
+    }
+
+    // todo, idea: have the "quest or mystery" part displayed at the beginning, to give the players a primer.
+    // todo, idea: use smaller, more numerous prompts to build up more internal intelligence: probably would be beneficial to first create text blocks describing each commander, their powers and personalities, etc. Also to create a description of their dynamics, and a description of the map settings. All for future state.
+    // Other optional parameters to learn about and explore: `max_tokens`, `n`, `temperature`. https://platform.openai.com/tokenizer
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+          { role: 'system', content: 'You are an expert at the game Magic the Gathering, and you will help to write short, dramatic stories drawing from user-provided content.' },
+          {
+              role: 'user',
+              content: `Please write a fun, engaging, and dramatic game summary based on the following game log. The player commanders are ${listOfCommanderNames(false)}, and they are cooperatively facing a series of enemy threats. Additionally, please create a mystery or quest which is thematic to the setting and commanders, and have that mystery or quest resolved at the game completion. The game log is: ${gameLog}`,
+          },
+      ],
+    });
+
+    // TODO: can also possibly generate an image to accompany the game conclusion:
+    // openai
+  // .images
+    // .generate({
+    //   prompt: `An image of ${commandersArray} standing victoriously together.`,
+    //   n: 2,
+    //   size: "1024x1024",
+    // })
+    // .then((response) => console.log(response.data));
+
+    console.log(`The game summary is: ${completion.choices[0].message.content}`);
+    return completion.choices[0].message.content;
+  }
 
   const populateModal = (cardData, modalText, modalButtonOptions) => {
     setCardToDisplay(cardData);
@@ -41,16 +97,15 @@ const App = () => {
     setIsModalOpen(false);
   };
 
-  const handleFileChange = (event) => {
+  const handleMapFileUpload = (event) => {
+    // TODO: need to validate map selection
     const file = event.target.files[0];
     if (file) {
       const reader = new FileReader();
       reader.onload = (e) => {
         try {
           const mapData = JSON.parse(e.target.result);
-          // set the quantitty maps here?
           setSelectedMap(mapData);
-
           setBackgroundImage(mapData.backgroundImage);
         } catch (error) {
           console.error("Error parsing JSON:", error);
@@ -59,6 +114,26 @@ const App = () => {
       reader.readAsText(file);
     }
   };
+
+  // A temporary, local solution. Will handle with secrets management in the future.
+  const initializeOpenAi = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const openAiKey = e.target.result;
+          // TODO: need to handle this with secrets management: https://github.com/MikeCaputo/kingston-ny-mtg/issues/8
+          // https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety
+          const thisOpenai = new OpenAI({ apiKey: openAiKey, dangerouslyAllowBrowser: true });
+          setOpenai(thisOpenai);
+        } catch (error) {
+          console.error("Error reading file:", error);
+        }
+      };
+      reader.readAsText(file);
+    }
+  }
 
   const generateBorderColors = (enemyBase) => {
     // Generate border color. Could maybe use refactoring but its okay for now.
@@ -90,6 +165,40 @@ const App = () => {
 
   }
 
+  const startTheGame = () => {
+    const commandersArray = [commander1, commander2, commander3, commander4];
+    const thisGameCommanders = commandersArray
+      .filter(commander => commander)  // Filter out empty strings
+      .map(commander => ({
+        commanderName: commander,
+        isAttacking: false
+      }));
+    
+    setCommandersArray(thisGameCommanders);
+    setIsGameStarted(true);
+  }
+
+  const listOfCommanderNames = (includeOnlyAttackers = false) => {
+    // Needs refinement. I think I did this exact same code in VoD somewhere.... this is good enough for now.
+    let text = '';
+    for (let i = 0; i < (commandersArray.length); i++) {
+      if(!includeOnlyAttackers || (includeOnlyAttackers && commandersArray[i].isAttacking)) {
+
+        if(i === commandersArray.length - 1) {
+          // text += '.';
+          text += ' and ';
+        }
+        if(commandersArray[i].commanderName) {
+          text += commandersArray[i].commanderName;
+        }
+        if(i < commandersArray.length - 1) {
+          text += ', ';
+        }
+      }
+    }
+    return text;
+  }
+
   return (
     <div className="App" style={{ backgroundImage: `url(/map-backgrounds/${backgroundImage})` }}>
 
@@ -99,15 +208,49 @@ const App = () => {
 
       <hr />
 
-      {!selectedMap &&
-        <input type="file" accept=".json,.js" onChange={handleFileChange} />
+      {!isGameStarted &&
+        <>
+          <p>1. Choose the map</p>
+          <input type="file" accept=".json,.js" onChange={handleMapFileUpload} />
+
+          <p>2. Add the OpenAI apiKey file (temporary solution)</p>
+          <input type="file" accept=".txt" onChange={initializeOpenAi} />
+
+          <p>3. Who are the Commander(s)?</p>
+          <input
+            type="text"
+            value={commander1}
+            onChange={e => setCommander1(e.target.value)}
+          /><br />
+          <input
+            type="text"
+            value={commander2}
+            onChange={e => setCommander2(e.target.value)}
+          /><br />
+          <input
+            type="text"
+            value={commander3}
+            onChange={e => setCommander3(e.target.value)}
+          /><br />
+          <input
+            type="text"
+            value={commander4}
+            onChange={e => setCommander4(e.target.value)}
+          /><br />
+
+          <button className="" onClick={startTheGame}>
+            Start the Game
+          </button>
+        </>
       }
 
-      {selectedMap && (
+      {isGameStarted && (
         <div>
-          <h2 className="map-header-name">Selected Map: {selectedMap.name}</h2>
+          <h2 className="map-header-name">Selected Map: {selectedMap?.name}</h2>
 
-          {selectedMap.enemyBases.map((enemyBase) => {
+          <h4>They are facing the combined forces of {listOfCommanderNames()}.</h4>
+
+          {selectedMap?.enemyBases.map((enemyBase) => {
 
             // Handle the ability to have multiple quantity of each Threat.
             const threats = [];
@@ -130,6 +273,11 @@ const App = () => {
                   attacksWith={enemyBase.attacksWith}
                   usesSpells={enemyBase.usesSpells}
                   rewards={enemyBase.rewards}
+                  commandersArray={commandersArray}
+                  setCommandersArray={setCommandersArray}
+                  listOfCommanderNames={listOfCommanderNames}
+                  addToGameLog={addToGameLog}
+                  generateGameSummary={generateGameSummary}
                 />
               );
             }

--- a/castle-siege/src/css/App.scss
+++ b/castle-siege/src/css/App.scss
@@ -77,6 +77,7 @@ button {
 
 .modal-content {
   margin-top: 20px;
+  white-space: pre-wrap; // Needed for AI-generated summary.
 }
 
 .map-header-name{

--- a/castle-siege/src/maps-data/geralfs-castle.json
+++ b/castle-siege/src/maps-data/geralfs-castle.json
@@ -119,7 +119,7 @@
           "isToken": false,
           "queryParameters": {
             "color": "black",
-            "power": 2,
+            "power": 3,
             "toughness": 2
           },
           "quantityRange": [3,5]


### PR DESCRIPTION
1. Adds input for player / commander names. Resolves this issue: https://github.com/MikeCaputo/kingston-ny-mtg/issues/5
2. Game actions are recorded in a log. Resolves this issue: https://github.com/MikeCaputo/kingston-ny-mtg/issues/6
3. This log is used to AI-generate a game recap, which is then displayed at the end. There is huge room to expand on this, but as a proof of concept this is a good first step.
4. Note, that the `openai` key is now added via a local file. A good solution for now, but a longer-term solution will be handled here: https://github.com/MikeCaputo/kingston-ny-mtg/issues/8
5. The code is not pristine, but it's in a good-enough state without agonizing over it too much at this point. Created several spin-out issues so this PR doesn't get too large. _I'm not fully focused on this project, so I don't want to get big PRs which will require a lot of mental upload for me._