### PR TITLE
Commanders can now be located at specific enemy bases

### DIFF
--- a/castle-siege/README.md
+++ b/castle-siege/README.md
@@ -10,26 +10,26 @@
 
 ### Overview
 
-The players will use stanard MtG Commander decks for this game variant; and the game experience is cooperative. The game is played on different customized maps. Each map will contain nodes, and the players will travel from one node to the next. Each node will contain a threat / enemy base that must be defeated before they can proceed. Finally, the players will have a powerful boss to defeat at the end.
+The players will use stanard MtG Commander decks for this game variant; and the game experience is cooperative. The game is played on different customized maps. Each map will contain nodes, and the players will travel from one node to the next. Each node will contain an enemy base that must be defeated before they can proceed. Finally, the players will have a powerful boss to defeat at the end.
 
 The game ends when the boss is defeated, or when all players are defeated.
 
 ### Game Rules
 - Players will be represented by some simple game piece on the map
-- Each node represents a threat to deal with. The players cannot advance until they have removed the threat. The threat will function similarly to an AI magic player, but for simplicity will not have a "board state"
+- Each node represents an enemy base to deal with. The players cannot advance until they have removed the enemy base. The enemy base will function similarly to an AI magic player, but for simplicity will not have a "board state"
 - Each turn, the player will play as normal.
   - They play lands, spells, creatures.
   - When they attack, the enemy has no blockers and casts no spells.
 - On the "enemy turn", different things can happen:
   - They will play one spell, or multiple spells. They will be chosen from a random set.
-  - Example: a red-colored threat might lightning bolt you. Or they could cast cataclysm, dealing 2 damage to all of your creatures.
+  - Example: a red-colored enemy base might lightning bolt you. Or they could cast cataclysm, dealing 2 damage to all of your creatures.
   - They will attack with creatures. These will be represented by "invisible" token creatures.
   - Example: "They attack you with four 1/1 goblins" or "They attack you with three 3/3 giants with trample"
-  - The idea is to represent a muscular threat, while minimizing board state complexity. The goal here is endurance, not complexity of board state. You as a player have a lot to punch through. Not all players might make it to the end.
-  - Early threats have smaller effects. Later threats use huge spells (make you discard your hand, wipe all your creatures, etc) and dish out powerful attacks. By late game, you need to have a strong and varied board state which will let you recover and endure.
-- When the threat is eliminated, a few things can happen:
-  - Players will receive some small rewards for defeating the threat; mainly thematic tokens (Treasure tokens, Clue tokens, Food tokens, etc)
-  - Future possibility: some global effect might get shut down. Will define and refine this idea later. _Example: Suppose some effect was in play: while you're in this swamp zone, each player loses 2 life during their upkeep. That effect could be shut down if a certain threat is defeated. This would facilitate branching maps._
+  - The idea is to represent a muscular enemy base, while minimizing board state complexity. The goal here is endurance, not complexity of board state. You as a player have a lot to punch through. Not all players might make it to the end.
+  - Early enemy bases have smaller effects. Later enemy bases use huge spells (make you discard your hand, wipe all your creatures, etc) and dish out powerful attacks. By late game, you need to have a strong and varied board state which will let you recover and endure.
+- When the enemy base is eliminated, a few things can happen:
+  - Players will receive some small rewards for defeating the enemy base; mainly thematic tokens (Treasure tokens, Clue tokens, Food tokens, etc)
+  - Future possibility: some global effect might get shut down. Will define and refine this idea later. _Example: Suppose some effect was in play: while you're in this swamp zone, each player loses 2 life during their upkeep. That effect could be shut down if a certain enemy base is defeated. This would facilitate branching maps._
 
 ### Long-term Goals
 - This could be controlled via a web app, accessible by anyone
@@ -38,18 +38,18 @@ The game ends when the boss is defeated, or when all players are defeated.
 
 ### Game design ideas:
 - Branching paths can lead to different strategies. There could be one amusing map where you can go to the Boss on turn one, but without a board state you'll get flattened. But there are different branching "back doors" that will let you build up your board state.
-- There could be branches that force you to deal with threats, but also gain reward bigger than usual. For example, there might be a storehouse area which you could battle, in order to get 10 food tokens. This could give you the staying power needed to make it to the end. And if your deck doesn't have lifegain, moreso. Could be similar things for clue tokens, flying creature tokens, etc.
-- When there are multiple players on a Threat at the same time, they take their turn together and attack together: two-headed giant rules
+- There could be branches that force you to deal with enemy bases, but also gain reward bigger than usual. For example, there might be a storehouse area which you could battle, in order to get 10 food tokens. This could give you the staying power needed to make it to the end. And if your deck doesn't have lifegain, moreso. Could be similar things for clue tokens, flying creature tokens, etc.
+- When there are multiple players on an enemy base at the same time, they take their turn together and attack together: two-headed giant rules
 - This allows the players to boost each other; for example, an effect that reads "All attacking creatures get +2/+0 until end of turn" would apply to both players. It will also allow the players to weather the enemy attacks more easily, with shared blockers. But watch out, because enemy spells will affect them all as well! Ex, Pyroclasm.
-When the enemy attacks, the players not only have shared blockers, but they also decide who gets dealt damage. So, if the Threat deals 20 damage, and there are two players there with life totals of 30 and 10, the player with the 30 life total can take all of the 20 damage. This can allow players with low life total to continue to participate and be "shielded" by another player with higher life.
-- When a Threat is defeated and rewards are given, the players at that location choose how to distribute the rewards amongst themselves.
+When the enemy attacks, the players not only have shared blockers, but they also decide who gets dealt damage. So, if the enemy base deals 20 damage, and there are two players there with life totals of 30 and 10, the player with the 30 life total can take all of the 20 damage. This can allow players with low life total to continue to participate and be "shielded" by another player with higher life.
+- When an enemy base is defeated and rewards are given, the players at that location choose how to distribute the rewards amongst themselves.
 - Effects that read "Target player" can be used at any time. So, on your turn you can let other players gain life, draw cards, etc.
 
 ### Rule Clarifications
-- Cards which read "Target Player" or "Target Opponent" can indeed target an enemy threat
+- Cards which read "Target Player" or "Target Opponent" can indeed target an enemy base
 - Cards which read "Target Player" can target another player. So, you can use a Maze of Ith to help your ally one turn.
-- But, cards which have global effects ("All creatures get -2/-2 until end of turn", "All players discard a card"), etc: these effects will only affect the threat and player(s) at the given node. Example: if a player casts Inferno to kill a Threat's attacking creatures, it does not affect players outside of that node.
-- When an enemy Threat attacks, their creatures are considered to _phase in_. They do not "enter the battlefield". So if you have a Soul Warden, and your enemy Threat attacks you with 8 goblins, you do not gain 8 life. _Similarly_, any unkilled enemy creatures _phase out_. They do not exit the battlefield.
+- But, cards which have global effects ("All creatures get -2/-2 until end of turn", "All players discard a card"), etc: these effects will only affect the enemy base and player(s) at the given node. Example: if a player casts Inferno to kill an enemy base's attacking creatures, it does not affect players outside of that node.
+- When an enemy base attacks, their creatures are considered to _phase in_. They do not "enter the battlefield". So if you have a Soul Warden, and your enemy base attacks you with 8 goblins, you do not gain 8 life. _Similarly_, any unkilled enemy creatures _phase out_. They do not exit the battlefield.
 
 ## Technical Notes
 

--- a/castle-siege/src/App.jsx
+++ b/castle-siege/src/App.jsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import './css/App.scss';
-import Threat from './Threat.js';
 import {
-  generateBorderColors,
   generateDescriptionForCommander,
   generateDynamicsBetweenCommanders,
   generateGamePrologue,
   listOfCommanderNames,
   openAiSettings,
-} from './helper-methods';
+} from './helper-methods.js';
 // OpenAI
 import OpenAI from 'openai';
 import CommanderPicker from './CommanderPicker.jsx';
@@ -21,8 +19,8 @@ const App = () => {
   const [modalText, setModalText] = useState(null);
 
   const [modalButtonText, setModalButtonText] = useState('');
-  const [modalButtonFunction, setModalButtonFunction] = useState(null); // wip
-  const [shouldModalBeOpen, setShouldModalBeOpen] = useState(null); // wip
+  // const [modalButtonFunction, setModalButtonFunction] = useState(null); // wip
+  // const [shouldModalBeOpen, setShouldModalBeOpen] = useState(null); // wip
   const [selectedMap, setSelectedMap] = useState(null);
   const [backgroundImage, setBackgroundImage] = useState(null);
   const [isGameStarted, setIsGameStarted] = useState(false);
@@ -38,33 +36,27 @@ const App = () => {
   useEffect(() => {
     // Sets the commanders array; only adds those with a value. The `filter` will exclude any non-nulls.
     setCommandersArray([commander1, commander2, commander3, commander4].filter(commander => commander));
-    console.log('commander1 is: ', commander1);
-    console.log('commander2 is: ', commander2);
-    console.log('commander3 is: ', commander3);
-    console.log('commander4 is: ', commander4);
-    console.log('commandersArray is: ', commandersArray);
-    console.log('commandersArray.length is: ', commandersArray.length);
   }, [commander1, commander2, commander3, commander4]);
 
   // Can worry about drying this up later if needed.
   const getCommanderByPlayerNumber = (playerNumber) => {
     switch(playerNumber) {
-      case 1: return commander1; break;
-      case 2: return commander2; break;
-      case 3: return commander3; break;
-      case 4: return commander4; break;
-      default: return null; break;
+      case 1: return commander1;
+      case 2: return commander2;
+      case 3: return commander3;
+      case 4: return commander4;
+      default: return null;
     }
   }
 
   // Could combine this with the above, probably.... it's okay for now.
   const getCommanderSetterByPlayerNumber = (playerNumber) => {
     switch(playerNumber) {
-      case 1: return setCommander1; break;
-      case 2: return setCommander2; break;
-      case 3: return setCommander3; break;
-      case 4: return setCommander4; break;
-      default: return null; break;
+      case 1: return setCommander1;
+      case 2: return setCommander2;
+      case 3: return setCommander3;
+      case 4: return setCommander4;
+      default: return null;
     }
   }
 
@@ -119,7 +111,7 @@ const App = () => {
       setModalText(modalText);
     }
 
-    // Populate the modal button. This will allow the modal to control multiple attacks per threat.
+    // Populate the modal button. This will allow the modal to control multiple attacks per enemy base.
     if(modalButtonOptions?.text) {
       setModalButtonText(modalButtonOptions.text);
     }
@@ -272,7 +264,7 @@ const App = () => {
             ))
           }
 
-          <button className="" onClick={startTheGame} disabled={!canStartTheGame}>
+          <button onClick={startTheGame} disabled={!canStartTheGame}>
             {canStartTheGame ? 'Start the Game' : 'Please finish setting up'}
           </button>
         </>
@@ -291,7 +283,6 @@ const App = () => {
             setIsModalOpen={setIsModalOpen}
             setModalText={setModalText}
             commandersArray={commandersArray}
-            setCommandersArray={setCommandersArray}
             addToGameLog={addToGameLog}
             generateGameSummary={generateGameSummary}
             openai={openai}
@@ -300,9 +291,7 @@ const App = () => {
         </div>
       )}
 
-      {/* <hr /> */}
-
-      {/* July 9: thinking about trimming this down, no longer using it for Threat-specific purposes. */}
+      {/* July 9: thinking about trimming this down, no longer using it for enemy base-specific purposes. */}
       {isModalOpen && (
         <div className="modal-overlay">
           <div className="modal">

--- a/castle-siege/src/CommanderDisplay.jsx
+++ b/castle-siege/src/CommanderDisplay.jsx
@@ -1,0 +1,24 @@
+import './css/App.scss';
+import React, { useState } from 'react';
+
+const CommanderDisplay = (props) => {
+
+  // Passed props
+  const commander = props.commander;
+  // console.log('commander in CommanderDisplay: ', commander)
+
+  return (
+    <section className="commander-display">
+
+      <img
+        src={commander.scryfallCardData.image_uris?.small}
+        alt={commander.scryfallCardData.name}
+        title={commander.scryfallCardData.name}
+      />
+      <p>Life total: {commander.lifeTotal}</p>
+
+    </section>
+  );
+}
+
+export default CommanderDisplay;

--- a/castle-siege/src/CommanderPicker.jsx
+++ b/castle-siege/src/CommanderPicker.jsx
@@ -28,12 +28,13 @@ const CommanderPicker = (props) => {
   }
 
   const chooseCommander = (selectedCard) => {
+
     setCommanderFunction(({
-      isAttacking: false,
+      hexLocation: null,
       lifeTotal: 40,
       playerNumber: playerNumber,
-      scryfallCardData: selectedCard // Set the card in the collection (from App.jsx)
-      // TBD: should I attach the `setCommanderFunction` function to the commander, so it will always have that context available? So you can say, "whatever commander I have here, run this function and update yourself"...? I should see if this is an antipattern, too clever for React's intended use.
+      scryfallCardData: selectedCard, // Set the card in the collection (from App.jsx)
+      selfUpdate: setCommanderFunction
     }))
   }
 

--- a/castle-siege/src/CommandersAtThisLocation.jsx
+++ b/castle-siege/src/CommandersAtThisLocation.jsx
@@ -1,0 +1,42 @@
+import './css/App.scss';
+import CommanderDisplay from './CommanderDisplay.jsx';
+
+const CommandersAtThisLocation = (props) => {
+
+  // Passed props
+  const commandersArray = props.commandersArray;
+
+  const updateCommanderLocation = (commander) => {
+    commander.selfUpdate({...commander, hexLocation: [props.hexCol, props.hexRow]});
+  }
+
+  const isCommanderAtThisLocation = (commander) => {
+    return commander.hexLocation && commander.hexLocation[0] === props.hexCol && commander.hexLocation[1] === props.hexRow;
+  }
+
+  return (
+    <section className="commanders-at-this-location">
+      {
+        commandersArray.map((commander, index) => (
+          isCommanderAtThisLocation(commander) ? (
+            <CommanderDisplay
+              key={index}
+              commander={commander}
+            />
+          ) : (
+            <button
+              key={index}
+              onClick={() => updateCommanderLocation(commander)}
+              className="move-commander-here-button"
+            >
+              Move {commander.scryfallCardData.name} here
+            </button>
+          )
+        ))
+      }
+    </section>
+
+  );
+}
+
+export default CommandersAtThisLocation;

--- a/castle-siege/src/Hex.jsx
+++ b/castle-siege/src/Hex.jsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import Threat from './Threat.js';
+import EnemyBase from './EnemyBase.jsx';
 import castleIcon from './images/castle-icon.png';
 import pathIcon from './images/path-icon.png';
-import { generateBorderColors} from './helper-methods';
+import { generateBorderColors, listOfCommanderNames } from './helper-methods';
 
-const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisHex, populateModal, closeModal, setIsModalOpen, setModalText, commandersArray, setCommandersArray, addToGameLog, generateGameSummary, openai }) => {
+const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisHex, populateModal, closeModal, setIsModalOpen, setModalText, commandersArray, addToGameLog, generateGameSummary, openai }) => {
   const hexWidth = size * 2;
   const hexHeight = Math.sqrt(3) * size;
 
@@ -30,7 +30,7 @@ const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisH
   };
 
   const onClick = () => {
-    console.log('clicked a hex! col is: ', col, ' and row is: ', row)
+    // console.log(`clicked a hex: column and row is  is: [${col},${row}]`)
     if(enemyBaseAtThisHex) {
       setDisplayEnemyBase(!displayEnemyBase);
     }
@@ -50,7 +50,7 @@ const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisH
   return (
     <>
       <span
-        // for debugging! set to display: none when not needed.
+        // Display hex coords. Can be used for debugging.
         style = {{
           display: 'none',
           position: 'absolute',
@@ -59,7 +59,17 @@ const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisH
           color: '#ff0000'
         }}
       >
-          {col}, {row}
+        {col}, {row}
+      </span>
+      <span
+        // In small text, display which commanders are at this location.
+        className='hex-commander-name-display'
+        style = {{
+          left: x + 30,
+          top: y,
+        }}
+      >
+        {listOfCommanderNames(commandersArray, true, [col, row])}
       </span>
       <svg
         onClick={() => onClick()}
@@ -82,12 +92,12 @@ const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisH
           fill={isHovered || displayEnemyBase ? baseHoverColor : baseFillColor} // Change fill on hover
           stroke={isHovered || displayEnemyBase ? '#f1c40f' : '#2980b9'} // Change stroke on hover
           strokeWidth={2}
-      />
+        />
       </svg>
 
       {
         enemyBaseAtThisHex &&
-          <Threat
+          <EnemyBase
             style={
               {
                 backgroundImage: `linear-gradient(white, white), linear-gradient(45deg, ${generateBorderColors(enemyBaseAtThisHex)})`,
@@ -96,20 +106,15 @@ const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisH
                 display: displayEnemyBase ? 'block' : 'none'
               }
             }
-            name={`${enemyBaseAtThisHex.name}`}
             key={`${enemyBaseAtThisHex.name}-${id}`} // Ensure unique keys for each instance (okay to give it the id of the hexGrid?)
-            isBoss={enemyBaseAtThisHex.isBoss}
-            lifeTotal={enemyBaseAtThisHex.lifeTotal}
+            enemyBaseAtThisHex={enemyBaseAtThisHex}
             populateModal={populateModal}
             closeModal={closeModal}
             setIsModalOpen={setIsModalOpen}
             setModalText={setModalText}
-            turnOrder={enemyBaseAtThisHex.turnOrder}
-            attacksWith={enemyBaseAtThisHex.attacksWith}
-            usesSpells={enemyBaseAtThisHex.usesSpells}
-            rewards={enemyBaseAtThisHex.rewards}
             commandersArray={commandersArray}
-            setCommandersArray={setCommandersArray}
+            hexCol={col}
+            hexRow={row}
             addToGameLog={addToGameLog}
             generateGameSummary={generateGameSummary}
             openai={openai}

--- a/castle-siege/src/HexGrid.jsx
+++ b/castle-siege/src/HexGrid.jsx
@@ -87,7 +87,6 @@ const HexGrid = (props) => {
             enemyBaseAtThisHex={hex.enemyBaseAtThisHex}
             isThereAPathAtThisHex={hex.isThereAPathAtThisHex}
             commandersArray={props.commandersArray}
-            setCommandersArray={props.setCommandersArray}
             addToGameLog={props.addToGameLog}
             generateGameSummary={props.generateGameSummary}
             openai={props.openai}

--- a/castle-siege/src/css/App.scss
+++ b/castle-siege/src/css/App.scss
@@ -109,11 +109,18 @@ button {
       background-position-x: center;
       background-position-y: center;
     }
+    .hex-commander-name-display {
+      display: block;
+      position: absolute;
+      color: #ffffff;
+      max-width: 100px;
+      z-index: 100
+    }
   }
 }
 
-/* Future: threats will have their MtG color(s) as props, and will get an appropriate (multi)colored background like this: https://blog.prototypr.io/css-only-multi-color-backgrounds-4d96a5569a20 */
-.Threat {
+/* Future: enemy bases will have their MtG color(s) as props, and will get an appropriate (multi)colored background like this: https://blog.prototypr.io/css-only-multi-color-backgrounds-4d96a5569a20 */
+.EnemyBase {
   position: absolute;
   z-index: 100;
   color: $dark-gray;
@@ -130,7 +137,7 @@ button {
   }
   &:hover, &:focus, &:active{
     &:not(.defeated) {
-      // Note: background color gradient is a parameter passed into the Threat as a prop. It is added as an inline style.
+      // Note: background color gradient is a parameter passed into the EnemyBase as a prop. It is added as an inline style.
       background-origin: border-box;
       background-clip: content-box, border-box;
       // box-shadow: #cccccc 10px 10px 10px;
@@ -164,3 +171,35 @@ button {
     border: 1px solid green;
   }
 }
+
+.commanders-at-this-location {
+
+  .commander-display, .move-commander-here-button {
+    margin: 10px;
+    border-radius: 15px;
+    background: #ffffff;
+    color: #000000;
+    width: auto;
+    display: inline-block;
+    vertical-align: top;
+    // Width / height are derived from the "small" image size of Scryfall.
+    width: 146px;
+    min-height: 204px;
+  }
+
+  .commander-display{
+    p {
+      margin: 5px 0 5px 0;
+    }
+  }
+
+  .move-commander-here-button {
+    border: 2px dashed #cccccc;
+    &:hover {
+      background: #eeeeee;
+      border-color: #666666;
+    }
+  }
+
+}
+

--- a/castle-siege/src/helper-methods.js
+++ b/castle-siege/src/helper-methods.js
@@ -80,33 +80,38 @@ export const generateBorderColors = (enemyBase) => {
 
 export const colorTranslate = (colorInitial) => {
   switch(colorInitial) {
-    case 'W': return 'white'; break;
-    case 'G': return 'green'; break;
-    case 'U': return 'blue'; break;
-    case 'R': return 'red'; break;
-    case 'B': return 'black'; break;
-    default: return null; break;
+    case 'W': return 'white';
+    case 'G': return 'green';
+    case 'U': return 'blue';
+    case 'R': return 'red';
+    case 'B': return 'black';
+    default: return null;
   }
 }
 
-export const listOfCommanderNames = (whichCommandersArray, includeOnlyAttackers = false) => {
-  // Needs refinement. I think I did this exact same code in VoD somewhere.... this is good enough for now.
+// The `includeOnlyThoseAtTheProvidedHexLocation` parameter, along with `hexLocation`, will allow to include only the commanders at a particular hex location.
+export const listOfCommanderNames = (whichCommandersArray, includeOnlyThoseAtTheProvidedHexLocation = false, hexLocation = []) => {
   let text = '';
-  for (let i = 0; i < (whichCommandersArray.length); i++) {
-    if(!includeOnlyAttackers || (includeOnlyAttackers && whichCommandersArray[i].isAttacking)) {
 
-      if(whichCommandersArray.length > 1 && i === whichCommandersArray.length - 1) {
-        // text += '.';
-        text += ' and ';
-      }
-      if(whichCommandersArray[i].scryfallCardData.name) {
-        text += whichCommandersArray[i].scryfallCardData.name;
-      }
-      if(i < whichCommandersArray.length - 1) {
-        text += ', ';
-      }
-    }
+  // Filter commanders based on hex location if the flag is set
+  if(includeOnlyThoseAtTheProvidedHexLocation) {
+    whichCommandersArray = whichCommandersArray.filter((commander) =>
+      commander.hexLocation && commander.hexLocation[0] === hexLocation[0] && commander.hexLocation[1] === hexLocation[1]
+    );
   }
+
+  // Iterate over filtered commanders and build the text string
+  whichCommandersArray.forEach((commander, i) => {
+    if(i === whichCommandersArray.length - 1 && whichCommandersArray.length > 1) {
+      text += ' and ';
+    }
+    text += commander.scryfallCardData.name;
+
+    if(i < whichCommandersArray.length - 1) {
+      text += ', '; // Add comma for all but the last item
+    }
+  });
+
   return text;
 }
 
@@ -132,12 +137,12 @@ export const generateDescriptionForCommander = async (openai, commander) => {
 
   const translateColorsToString = (colorsArray, i) => {
     let colorsString = '';
-    colorsArray.map(colorInitial => {
+    colorsArray.forEach((colorInitial, index) => {
       colorsString += colorTranslate(colorInitial);
-      if(colorsArray.length > 1 && i === colorsArray.length - 1) {
+      if(colorsArray.length > 1 && index === colorsArray.length - 1) {
         colorsString += ' and ';
       }
-    })
+    });
     return colorsString;
   }
 

--- a/castle-siege/tests/bdd-tests.md
+++ b/castle-siege/tests/bdd-tests.md
@@ -88,6 +88,7 @@ THEN the modal will close
 AND I will see a hex grid
 AND the grid will have map-specific enemy bases, represented by castle icons
 AND the grid will have map-specific connecting paths, represented by stone path icons
+AND the grid will display where the commanders are, in plain text
 
 ## Hex Grid
 
@@ -98,6 +99,7 @@ AND I see a hex grid
 AND I see at least one enemy base, represented by a castle
 WHEN I click on the castle
 THEN the enemy base will be displayed
+AND I will see button(s) which would allow me to move commander(s) to this location
 AND the enemy base will show its name
 AND the enemy base will have a life total
 AND the enemy base will have a field allowing the player(s) to damage that base
@@ -116,12 +118,32 @@ AND that enemy base is open
 WHEN I click on the castle
 THEN the enemy base will close
 
+### Scenario: I can click on any hex grids to see its coordinates in the console log
+GIVEN I am Castle Siege developer
+AND I have started the game
+AND I see a hex grid
+AND I have browser developer tools open
+WHEN I click on any hex
+THEN I will see the column and row numbers for that hex
+AND I can use that information to debug and/or edit map information
+
 ## Enemy Bases
+
+### Scenario: I can move a commander to an enemy base
+GIVEN I am a player
+AND I have started the game
+AND there is an opened enemy base
+AND I see button(s) which would allow me to move commander(s) to this location
+WHEN I click one to move the desired commander to that location
+THEN I will see that commander's card image
+AND I will see that commander's life total
+AND I will no longer have the ability to move that commander to that location
+AND that commander will no longer be displayed at any other location
 
 ### Scenario: I initiate an enemy base turn
 GIVEN I am a player
 AND I have started the game
-AND there is an enemy base
+AND there is an opened enemy base
 AND that enemy base has more than 0 life total
 WHEN I begin their turn
 THEN the enemy base UI will expand to display a card
@@ -130,7 +152,7 @@ AND they will cast a spell or perform an attack
 ### Scenario: An enemy base takes an additional action
 GIVEN I am a player
 AND I have started the game
-AND there is an enemy base
+AND there is an opened enemy base
 AND that enemy base has more than 0 life total
 AND that enemy has started their turn
 AND they have an additional action
@@ -140,7 +162,7 @@ THEN they will cast a spell or perform an attack
 ### Scenario: An enemy base finishes their turn
 GIVEN I am a player
 AND I have started the game
-AND there is an enemy base
+AND there is an opened enemy base
 AND that enemy base has more than 0 life total
 AND that enemy has started their turn
 AND they have no additional actions
@@ -150,9 +172,9 @@ THEN the enemy base UI will partially collapse
 ### Scenario: One or more players deals damage to an enemy base
 GIVEN I am a player
 AND I have started the game
-AND there is an enemy base
+AND there is an opened enemy base
 AND that enemy base has more than 0 life total
-AND one or more players are attacking that base
+AND one or more players are located at that base
 AND a damage amount has been populated
 WHEN I deal damage to the enemy base
 AND that will not cause the enemy life total to drop to 0 or below 0
@@ -161,9 +183,9 @@ THEN the enemy base life total will decrease by that amount
 ### Scenario: A non-boss enemy base is defeated
 GIVEN I am a player
 AND I have started the game
-AND there is an enemy base
+AND there is an opened enemy base
 AND that enemy base has more than 0 life total
-AND one or more players are attacking that base
+AND one or more players are located at that base
 WHEN I deal damage to the enemy base
 AND that causes the enemy life total to drop to 0 or below 0
 AND that enemy is not a boss
@@ -183,9 +205,9 @@ AND that enemy base will no longer have a hover state
 ### Scenario: The boss enemy base is defeated
 GIVEN I am a player
 AND I have started the game
-AND there is an enemy base
+AND there is an opened enemy base
 AND that enemy base has more than 0 life total
-AND one or more players are attacking that base
+AND one or more players are located at that base
 WHEN I deal damage to the enemy base
 AND that causes the enemy life total to drop to 0 or below 0
 AND that enemy is a boss


### PR DESCRIPTION
## Commanders can now be located at specific enemy bases

1. Each EnemyBase now has button(s) which allow the players to move Commanders to the different locations.
    - Related to this, all commanders at a given location are part of an attack against the enemy base. Will no longer be manually selected.
    - Commander names are also displayed on the hex grid. Small, simple UI which might be refined in the future.
2. Commanders can now call their own setter function. I think this is a bit like a factory pattern, where I'm passing in a reference to a "composed" function to each commander. This is helping to simplify the number of props needing to be passed around to the different components.
3. Unrelated: remove all references to "Threats". Rename everything to "EnemyBases".
4. Resolve a bunch of linter warnings.
5. BDD test updates
6. **Note**: Commander life is displayed, but cannot be updated yet. That will come next. Trying to make smaller, more manageable PRs.