### PR TITLE
Can set commander life total, and commanders can be defeated

### DIFF
--- a/castle-siege/src/App.jsx
+++ b/castle-siege/src/App.jsx
@@ -38,7 +38,30 @@ const App = () => {
   // When a user selects a commander from the picker, reset the selector.
   useEffect(() => {
     // Sets the commanders array; only adds those with a value. The `filter` will exclude any non-nulls.
-    setCommandersArray([commander1, commander2, commander3, commander4].filter(commander => commander));
+    const commandersToCheck = [commander1, commander2, commander3, commander4].filter(commander => commander);
+
+    // Check if any commander's lifeTotal is zero or below; will be used to handle if a commander is defeated.
+    let potentiallyDefeatedCommander = null;
+    commandersToCheck.forEach(commander => {
+      if(commander.lifeTotal <= 0 && !commander.isDefeated) {
+        potentiallyDefeatedCommander = commander;
+      }
+    });
+
+    // If any commander is defeated, prompt the user
+    if(potentiallyDefeatedCommander) {
+      const confirmDefeat = window.confirm(`Alas! Has ${potentiallyDefeatedCommander.scryfallCardData.name} truly been defeated?`);
+      // If defeated, mark them as truly being defeated, and remove their hex location to simplify logic elsewhere. They are no longer "anywhere". If not defeated, set them at 1 life total.
+      const valueToUpdate = confirmDefeat ? { isDefeated: true, hexLocation: null } : { lifeTotal: 1 };
+      potentiallyDefeatedCommander.selfUpdate({ ...potentiallyDefeatedCommander, ...valueToUpdate });
+      if(confirmDefeat) {
+        addToGameLog(`Alas, ${potentiallyDefeatedCommander.scryfallCardData.name} has been defeated!`);
+      }
+      return; // Fast-exit here, so we don't get an infinite loop of confirm prompts.
+    }
+
+    // If confirmed or no defeated commander, update the commanders array
+    setCommandersArray(commandersToCheck);
   }, [commander1, commander2, commander3, commander4]);
 
   // Can worry about drying this up later if needed.

--- a/castle-siege/src/CommanderDisplay.jsx
+++ b/castle-siege/src/CommanderDisplay.jsx
@@ -5,6 +5,7 @@ const CommanderDisplay = (props) => {
 
   // Passed props
   const commander = props.commander;
+  const canChangeLifeTotal = props.canChangeLifeTotal;
   // console.log('commander in CommanderDisplay: ', commander)
 
   return (
@@ -15,7 +16,16 @@ const CommanderDisplay = (props) => {
         alt={commander.scryfallCardData.name}
         title={commander.scryfallCardData.name}
       />
-      <p>Life total: {commander.lifeTotal}</p>
+
+      <label>
+        Life Total
+        <input
+          type="number"
+          value={commander.lifeTotal}
+          onChange={e => commander.selfUpdate({...commander, lifeTotal: Math.max(e.target.value, 0)})}
+          disabled={!canChangeLifeTotal}
+        />
+      </label>
 
     </section>
   );

--- a/castle-siege/src/CommanderPicker.jsx
+++ b/castle-siege/src/CommanderPicker.jsx
@@ -32,6 +32,7 @@ const CommanderPicker = (props) => {
     setCommanderFunction(({
       hexLocation: null,
       lifeTotal: 40,
+      isDefeated: false,
       playerNumber: playerNumber,
       scryfallCardData: selectedCard, // Set the card in the collection (from App.jsx)
       selfUpdate: setCommanderFunction

--- a/castle-siege/src/CommandersAtThisLocation.jsx
+++ b/castle-siege/src/CommandersAtThisLocation.jsx
@@ -5,6 +5,7 @@ const CommandersAtThisLocation = (props) => {
 
   // Passed props
   const commandersArray = props.commandersArray;
+  const isEnemyBaseAlive = props.isEnemyBaseAlive;
 
   const updateCommanderLocation = (commander) => {
     commander.selfUpdate({...commander, hexLocation: [props.hexCol, props.hexRow]});
@@ -18,25 +19,33 @@ const CommandersAtThisLocation = (props) => {
     <section className="commanders-at-this-location">
       {
         commandersArray.map((commander, index) => (
-          isCommanderAtThisLocation(commander) ? (
-            <CommanderDisplay
-              key={index}
-              commander={commander}
-            />
-          ) : (
-            <button
-              key={index}
-              onClick={() => updateCommanderLocation(commander)}
-              className="move-commander-here-button"
-            >
-              Move {commander.scryfallCardData.name} here
-            </button>
-          )
+          <>
+            {commander.isDefeated && (
+              <p className="commander-has-been-defeated-text">Alas, {commander.scryfallCardData.name} is defeated!</p>
+            )}
+  
+            {!commander.isDefeated && (
+              isCommanderAtThisLocation(commander) ? (
+                <CommanderDisplay
+                  key={index}
+                  commander={commander}
+                  canChangeLifeTotal={isEnemyBaseAlive}
+                />
+              ) : (
+                <button
+                  onClick={() => updateCommanderLocation(commander)}
+                  className="move-commander-here-button"
+                >
+                  Move {commander.scryfallCardData.name} here
+                </button>
+              )
+            )}
+          </>
         ))
       }
     </section>
-
   );
+
 }
 
 export default CommandersAtThisLocation;

--- a/castle-siege/src/EnemyBase.jsx
+++ b/castle-siege/src/EnemyBase.jsx
@@ -61,6 +61,18 @@ const EnemyBase = (props) => {
     }
   };
 
+  // Only enable button functionalities if there are living commanders at the enemy base location.
+  const [areThereLivingCommandersAtThisBase, setAreThereLivingCommandersAtThisBase] = useState(false);
+  useEffect(() => {
+    const howManyLivingCommandersHere = commandersArray.filter((commander) =>
+      !commander.isDefeated &&
+      commander.hexLocation &&
+      commander.hexLocation[0] === props.hexCol &&
+      commander.hexLocation[1] === props.hexRow
+    ).length;
+    setAreThereLivingCommandersAtThisBase(howManyLivingCommandersHere > 0);
+  }, [commandersArray]);
+
   // This reacts to `currentActionIndex`, determining the rendering of the turn order.
   useEffect(() => {
     // console.log(`in the useEffect; currentActionIndex is ${currentActionIndex}`)
@@ -131,7 +143,7 @@ const EnemyBase = (props) => {
       enemyBaseIsDefeated();
     }
 
-    addToGameLog(`${listOfCommanderNames(commandersArray, true, [props.hexCol, props.hexRow])} deals ${damageToDealToEnemyBase} damage to ${enemyBaseName}${newLifeTotal === 0 ? ', defeating it!' : '.'}`);
+    addToGameLog(`${listOfCommanderNames(commandersArray, false, true, [props.hexCol, props.hexRow])} deals ${damageToDealToEnemyBase} damage to ${enemyBaseName}${newLifeTotal === 0 ? ', defeating it!' : '.'}`);
 
     setDamageToDealToEnemyBase(0); // Reset the input
   };
@@ -176,10 +188,13 @@ const EnemyBase = (props) => {
       style={props.style}
     >
 
+      <button className="close-enemy-base" onClick={() => setDisplayEnemyBase(false)}>X</button>
+
       <CommandersAtThisLocation
         commandersArray={commandersArray}
         hexCol={props.hexCol}
         hexRow={props.hexRow}
+        isEnemyBaseAlive={isEnemyBaseAlive}
       />
 
       <hr />
@@ -198,9 +213,12 @@ const EnemyBase = (props) => {
               value={damageToDealToEnemyBase}
               onChange={e => setDamageToDealToEnemyBase(e.target.value)}
               onFocus={(e) => e.target.select()}
+              disabled={!areThereLivingCommandersAtThisBase}
             />
           </label>
-          <button onClick={dealDamageToEnemyBase}>Deal damage to this Enemy Base</button>
+          <button onClick={dealDamageToEnemyBase} disabled={!areThereLivingCommandersAtThisBase}>
+            Deal damage to this Enemy Base
+          </button>
 
           <label>
             <span>Notes:</span>
@@ -233,7 +251,7 @@ const EnemyBase = (props) => {
             </>
           }
           {!isTurnUnderway &&
-            <button onClick={rotateThroughTurn}>
+            <button onClick={rotateThroughTurn} disabled={!areThereLivingCommandersAtThisBase}>
               {'Begin Turn'}
             </button>
           }
@@ -244,8 +262,6 @@ const EnemyBase = (props) => {
           </button> */}
         </>
       }
-
-      <button onClick={() => setDisplayEnemyBase(false)}><em>Close Enemy Base</em></button>
 
     </section>
   );

--- a/castle-siege/src/Hex.jsx
+++ b/castle-siege/src/Hex.jsx
@@ -69,7 +69,7 @@ const Hex = ({ x, y, col, row, size, id, enemyBaseAtThisHex, isThereAPathAtThisH
           top: y,
         }}
       >
-        {listOfCommanderNames(commandersArray, true, [col, row])}
+        {listOfCommanderNames(commandersArray, false, true, [col, row])}
       </span>
       <svg
         onClick={() => onClick()}

--- a/castle-siege/src/css/App.scss
+++ b/castle-siege/src/css/App.scss
@@ -127,7 +127,7 @@ button {
   background-color: rgba(255,255,255,.85);
   border-radius: 15px;
   display: block;
-  width: 550px;
+  min-width: 550px;
   transition: min-height 1s linear;
   padding: 5px; // lowering this to handle the new curved-border, with the gradient color.
   border: 5px solid transparent;
@@ -152,6 +152,16 @@ button {
       text-decoration: line-through;
     }
   }
+  button.close-enemy-base {
+    position: absolute;
+    top: 5px;
+    right: 10px;
+    min-width: revert;
+    min-height: revert;
+    width: 40px;
+    height: 40px;
+    border-radius: 100px;
+  }
 }
 
 .commander-selection-image {
@@ -174,7 +184,7 @@ button {
 
 .commanders-at-this-location {
 
-  .commander-display, .move-commander-here-button {
+  .commander-display, .move-commander-here-button, .commander-has-been-defeated-text {
     margin: 10px;
     border-radius: 15px;
     background: #ffffff;
@@ -185,12 +195,30 @@ button {
     // Width / height are derived from the "small" image size of Scryfall.
     width: 146px;
     min-height: 204px;
+    input[type=number] {
+      display: inline-block;
+      width: 40px;
+      border-radius: 5px;
+      padding: 5px;
+      margin-left: 5px;
+    }
   }
 
   .commander-display{
     p {
       margin: 5px 0 5px 0;
     }
+    &.defeated {
+      color: #cccccc;
+      img {
+        opacity: .5;
+      }
+    }
+  }
+
+  .commander-has-been-defeated-text {
+    background: #eeeeee;
+    color: #999999;
   }
 
   .move-commander-here-button {

--- a/castle-siege/src/helper-methods.js
+++ b/castle-siege/src/helper-methods.js
@@ -90,8 +90,13 @@ export const colorTranslate = (colorInitial) => {
 }
 
 // The `includeOnlyThoseAtTheProvidedHexLocation` parameter, along with `hexLocation`, will allow to include only the commanders at a particular hex location.
-export const listOfCommanderNames = (whichCommandersArray, includeOnlyThoseAtTheProvidedHexLocation = false, hexLocation = []) => {
+export const listOfCommanderNames = (whichCommandersArray, includeDefeatedCommanders = false, includeOnlyThoseAtTheProvidedHexLocation = false, hexLocation = []) => {
   let text = '';
+
+  // Filter out defeated commanders, if the flag is set
+  if(!includeDefeatedCommanders) {
+    whichCommandersArray = whichCommandersArray.filter((commander) => !commander.isDefeated);
+  }
 
   // Filter commanders based on hex location if the flag is set
   if(includeOnlyThoseAtTheProvidedHexLocation) {
@@ -166,7 +171,7 @@ export const generateDescriptionForCommander = async (openai, commander) => {
 
 export const generateDynamicsBetweenCommanders = async (openai, whichCommandersArray) => {
 
-  const aiInstructionPrompt = `The MtG commanders ${listOfCommanderNames(whichCommandersArray, false)} are cooperatively allied in a great battle against a powerful enemy. Please write a rich description of the dynamics and interactions between these commanders, taking into account their overall character attributes.`;
+  const aiInstructionPrompt = `The MtG commanders ${listOfCommanderNames(whichCommandersArray, false, false)} are cooperatively allied in a great battle against a powerful enemy. Please write a rich description of the dynamics and interactions between these commanders, taking into account their overall character attributes.`;
   console.log(`aiInstructionPrompt is: ${aiInstructionPrompt}`);
   const completion = await openai.chat.completions.create({
     ...openAiSettings(),

--- a/castle-siege/tests/bdd-tests.md
+++ b/castle-siege/tests/bdd-tests.md
@@ -4,7 +4,7 @@ _I can break this into multiple files in the future, if needed_
 
 ## Game Setup
 
-### Scenario: I first open the Castle Siege app
+**Scenario: I first open the Castle Siege app**
 GIVEN I am a player
 AND I have just opened the Castle Siege app
 WHEN I observe the page
@@ -13,13 +13,13 @@ AND I will see that I have the ability to add an OpenAI key
 AND I will see that I have the ability to populate the game with up to 4 commanders
 AND I will see that the button to start the game is disabled
 
-### Scenario: I can open a dialog box, allowing me select a map file
+**Scenario: I can open a dialog box, allowing me select a map file**
 GIVEN I am a player
 AND I have not started the game yet
 WHEN I select "Choose File" beneath the "Choose the map" section
 THEN a system dialogue will appear, allowing me to select a map file
 
-### Scenario: I select a map to play
+**Scenario: I select a map to play**
 GIVEN I am a player
 AND I have not started the game yet
 AND I can see a system dialogue, allowing me to select a `.json` map file
@@ -27,28 +27,28 @@ WHEN I select a file containing a Castle Siege map
 THEN the file name will appear next to the "Choose the file" button
 AND the map's background image will appear over a portion of the page
 
-### Scenario: I can open a dialog box, allowing me select a file containing an OpenAI API key
+**Scenario: I can open a dialog box, allowing me select a file containing an OpenAI API key**
 GIVEN I am a player
 AND I have not started the game yet
 WHEN I select "Choose File" beneath the "Choose the map" section
 THEN a system dialogue will appear, allowing me to select a `.txt` file containing an OpenAI API key
 * _Note: this is a temporary solution. Long-term this will be handled via secrets management. https://github.com/MikeCaputo/kingston-ny-mtg/issues/8_
 
-### Scenario: I select a file containing an OpenAI API key
+**Scenario: I select a file containing an OpenAI API key**
 GIVEN I am a player
 AND I have not started the game yet
 AND I can see a system dialogue, allowing me to select a `.txt` file
 WHEN I select a file containing an OpenAI API key
 THEN the file name will appear next to the "Choose the file" button
 
-### Scenario: I can search for a card to choose as my commander
+**Scenario: I can search for a card to choose as my commander**
 GIVEN I am a player
 AND I have not started the game yet
 AND I have added text to one of the input fields beneath the title "Who are the Commander(s)?"
 WHEN I blur out of the input field
 THEN I will see a list of cards which contain the input value as part of its card title
 
-### Scenario: I choose a card as my commander
+**Scenario: I choose a card as my commander**
 GIVEN I am a player
 AND I have not started the game yet
 AND I have added text to one of the input fields beneath the title "Who are the Commander(s)?"
@@ -58,7 +58,7 @@ THEN my selected card will appear alone
 AND I will no longer see the accompanying text input fields
 AND my card will no longer be selectable
 
-### Scenario: I see the ability to start the game
+**Scenario: I see the ability to start the game**
 GIVEN I am a player
 AND I have not started the game yet
 AND I have chosen a Castle Siege map
@@ -68,7 +68,7 @@ WHEN I observe the button at the bottom of the page
 THEN I will see that the button to start the game is no longer disabled
 AND it will read "Start the Game"
 
-### Scenario: I start the game, and see a prologue modal
+**Scenario: I start the game, and see a prologue modal**
 GIVEN I am a player
 AND I have not started the game yet
 AND the button to start the game is no longer disabled
@@ -79,7 +79,7 @@ AND it will contain an AI-generated game prologue
 AND that prologue will draw from the selected commander(s) and the map setting
 AND I will see a button reads "Let the Siege Begin!"
 
-### Scenario: I close the prologue modal and I can now interact with the game
+**Scenario: I close the prologue modal and I can now interact with the game**
 GIVEN I am a player
 AND I can see an AI-generated game prologue in a modal
 AND I see a button reads "Let the Siege Begin!"
@@ -88,18 +88,18 @@ THEN the modal will close
 AND I will see a hex grid
 AND the grid will have map-specific enemy bases, represented by castle icons
 AND the grid will have map-specific connecting paths, represented by stone path icons
-AND the grid will display where the commanders are, in plain text
+AND the grid will display where the living commanders are, in plain text
 
 ## Hex Grid
 
-### Scenario: I can open an enemy base
+**Scenario: I can open an enemy base**
 GIVEN I am a player
 AND I have started the game
 AND I see a hex grid
 AND I see at least one enemy base, represented by a castle
 WHEN I click on the castle
 THEN the enemy base will be displayed
-AND I will see button(s) which would allow me to move commander(s) to this location
+AND I will see button(s) which would allow me to move living commander(s) to this location
 AND the enemy base will show its name
 AND the enemy base will have a life total
 AND the enemy base will have a field allowing the player(s) to damage that base
@@ -109,7 +109,7 @@ AND the enemy base will have a Notes section
 AND the enemy base will have a button allowing the enemy base to take its turn
 AND the enemy base will have a button allowing the player to close the enemy base
 
-### Scenario: I can close an enemy base
+**Scenario: I can close an enemy base**
 GIVEN I am a player
 AND I have started the game
 AND I see a hex grid
@@ -118,7 +118,7 @@ AND that enemy base is open
 WHEN I click on the castle
 THEN the enemy base will close
 
-### Scenario: I can click on any hex grids to see its coordinates in the console log
+**Scenario: I can click on any hex grids to see its coordinates in the console log**
 GIVEN I am Castle Siege developer
 AND I have started the game
 AND I see a hex grid
@@ -129,27 +129,28 @@ AND I can use that information to debug and/or edit map information
 
 ## Enemy Bases
 
-### Scenario: I can move a commander to an enemy base
+**Scenario: I can move a commander to an enemy base**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
-AND I see button(s) which would allow me to move commander(s) to this location
+AND I see button(s) which would allow me to move living commander(s) to this location
 WHEN I click one to move the desired commander to that location
 THEN I will see that commander's card image
 AND I will see that commander's life total
 AND I will no longer have the ability to move that commander to that location
 AND that commander will no longer be displayed at any other location
 
-### Scenario: I initiate an enemy base turn
+**Scenario: I initiate an enemy base turn**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
 AND that enemy base has more than 0 life total
+AND there is at least one living commander at this base
 WHEN I begin their turn
 THEN the enemy base UI will expand to display a card
 AND they will cast a spell or perform an attack
 
-### Scenario: An enemy base takes an additional action
+**Scenario: An enemy base takes an additional action**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
@@ -159,7 +160,7 @@ AND they have an additional action
 WHEN I continue their turn
 THEN they will cast a spell or perform an attack
 
-### Scenario: An enemy base finishes their turn
+**Scenario: An enemy base finishes their turn**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
@@ -169,30 +170,30 @@ AND they have no additional actions
 WHEN I end their turn
 THEN the enemy base UI will partially collapse
 
-### Scenario: One or more players deals damage to an enemy base
+**Scenario: One or more players deals damage to an enemy base**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
 AND that enemy base has more than 0 life total
-AND one or more players are located at that base
+AND there is at least one living commander at this base
 AND a damage amount has been populated
 WHEN I deal damage to the enemy base
 AND that will not cause the enemy life total to drop to 0 or below 0
 THEN the enemy base life total will decrease by that amount
 
-### Scenario: A non-boss enemy base is defeated
+**Scenario: A non-boss enemy base is defeated**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
 AND that enemy base has more than 0 life total
-AND one or more players are located at that base
+AND there is at least one living commander at this base
 WHEN I deal damage to the enemy base
 AND that causes the enemy life total to drop to 0 or below 0
 AND that enemy is not a boss
 THEN a victory modal will appear
 AND reward item(s) will be distributed to the players located at that base
 
-### Scenario: I close a victory modal
+**Scenario: I close a victory modal**
 GIVEN I am a player
 AND I have started the game
 AND I have just defeated an enemy base
@@ -202,12 +203,12 @@ THEN the modal will close
 AND that enemy base will no longer have the ability to take a turn, or have damage dealt to it
 AND that enemy base will no longer have a hover state
 
-### Scenario: The boss enemy base is defeated
+**Scenario: The boss enemy base is defeated**
 GIVEN I am a player
 AND I have started the game
 AND there is an opened enemy base
 AND that enemy base has more than 0 life total
-AND one or more players are located at that base
+AND there is at least one living commander at this base
 WHEN I deal damage to the enemy base
 AND that causes the enemy life total to drop to 0 or below 0
 AND that enemy is a boss
@@ -217,3 +218,52 @@ AND the modal will populate with an AI-generated game epilogue once it is finish
 AND that epilogue will contain elements related to the game commander(s)
 AND that epilogue will contain elements related to the map elements
 AND that epilogue will contain references to the actions taken during the game
+
+## Players taking damage
+
+**Scenario: A player takes non-lethal damage**
+GIVEN I am a player
+AND I have started the game
+AND there is an opened enemy base
+AND that enemy base has more than 0 life total
+AND there is at least one living commander at this base
+WHEN I change the life total of a commander
+AND that value is 1 or greater
+THEN the life total changes
+
+**Scenario: A player sets lethal damage to a commander, and will see a prompt to confirm defeat or not**
+GIVEN I am a player
+AND I have started the game
+AND there is an opened enemy base
+AND that enemy base has more than 0 life total
+AND there is at least one living commander at this base
+WHEN I change the life total of a commander
+AND that value is 0 or less
+THEN I will see a prompt appear, asking me to confirm if the commander is indeed defeated
+
+**Scenario: A player does not confirm lethal damage to a commander**
+GIVEN I am a player
+AND I have started the game
+AND there is an opened enemy base
+AND that enemy base has more than 0 life total
+AND there is at least one living commander at this base
+AND I have changed the life total of the commander to a value 0 or less
+AND I see a prompt asking me if the commander is indeed defeated
+WHEN I do not confirm
+THEN the commander's life total becomes 1
+AND the commander is not defeated
+
+**Scenario: A player confirms lethal damage to a commander**
+GIVEN I am a player
+AND I have started the game
+AND there is an opened enemy base
+AND that enemy base has more than 0 life total
+AND there is at least one living commander at this base
+AND I have changed the life total of the commander to a value 0 or less
+AND I see a prompt asking me if the commander is indeed defeated
+WHEN I confirm that the commander is defeated
+THEN the commander is defeated
+AND the commander is no longer shown at this enemy base
+AND the commander can no longer be moved to any enemy base
+AND the commander's name no longer appears on the hex grid
+AND the commander's name no longer appears in the list of commander names below the selected map name


### PR DESCRIPTION
# Can set commander life total, and commanders can be defeated

1. Can set commander life total, and commanders can be defeated
2. When defeated, commanders:
    - Are no longer represented on the map
    - Can no longer be moved to enemy bases
    - Are no longer included in game logs during attacks against an enemy base
    - Add to game log when a commander is defeated.
3. Disable enemy base button functionalities if there are no living commanders present.
4. Commanders can no longer be damaged at a defeated enemy base.
5. Better button for closing an enemy base
6. BDD tests